### PR TITLE
SNMPv3 support for check_snmp_extend

### DIFF
--- a/README
+++ b/README
@@ -29,6 +29,19 @@ Usage::
                             SNMP extend name [default: ALL]
       -t TIMEOUT, --timeout=TIMEOUT
                             Timeout [default: 10]
+      -u SNMP_USER, --user=SNMP_USER
+                            SNMP username (v3 only)
+      -l SNMP_SECLEVEL, --seclevel=SNMP_SECLEVEL
+                            SNMP Seclevel (noAuthNoPriv|authNoPriv|authPriv, v3
+                            only)
+      -a SNMP_AUTHPROTO, --authproto=SNMP_AUTHPROTO
+                            SNMP Authentication protocol (MD5 or SHA, v3 only)
+      -A SNMP_AUTHPASS, --authpass=SNMP_AUTHPASS
+                            SNMP Authentication password (v3 only)
+      -x SNMP_PRIVPROTO, --privproto=SNMP_PRIVPROTO
+                            SNMP privacy protocol (DES or AES, v3 only)
+      -X SNMP_PRIVPASS, --privpass=SNMP_PRIVPASS
+                            SNMP privacy password (v3 only)
 
         
         HOW TO ADD A SNMP EXEC (EXTEND) :

--- a/check_snmp_extend.py
+++ b/check_snmp_extend.py
@@ -148,7 +148,6 @@ def check_snmp_extend():
 	noexecstr="::nsExtendResult = No Such Instance currently exists at this OID"
         if options.snmp_version == '3':
 		snmp_request="snmpwalk -v%s -u %s -l %s -a %s -A %s -x %s -X %s -OQ %s 'NET-SNMP-EXTEND-MIB::nsExtendResult'" % (options.snmp_version, options.snmp_user, options.snmp_seclevel, options.snmp_authproto, options.snmp_authpass, options.snmp_privproto, options.snmp_privpass, options.host)
-		exit
 	else:
 		snmp_request="snmpwalk -v%s -c %s -OQ %s 'NET-SNMP-EXTEND-MIB::nsExtendResult'" % (options.snmp_version, options.community, options.host)
 	
@@ -164,7 +163,6 @@ def check_snmp_extend():
 	
 	if options.snmp_version == '3':
 		snmp_request="snmpwalk -v%s -u %s -l %s -a %s -A %s -x %s -X %s -OQ %s 'NET-SNMP-EXTEND-MIB::nsExtendOutputFull'" % (options.snmp_version, options.snmp_user, options.snmp_seclevel, options.snmp_authproto, options.snmp_authpass, options.snmp_privproto, options.snmp_privpass, options.host)
-		exit
 	else:
 		snmp_request="snmpwalk -v%s -c %s -OQ %s 'NET-SNMP-EXTEND-MIB::nsExtendOutputFull'" % (options.snmp_version, options.community, options.host)
 


### PR DESCRIPTION
Added initial support for SNMPv3 with --user, --seclevel, --authproto, --authpass, --privproto, and --privpass Optparse options.  Also modified the --output-longoutput format toggle to be '-L' (instead of '-l') so the SNMPv3 options would more closely match their snmpcmd counterparts.  One caveat is that the script expects SNMPv3 support to have a username, seclevel, auth{pass,proto}, and priv{proto,pass}, and some 'lesser' implementations of SNMPv3 don't necessarily need all of those to function.

There was also a minor typo in the example text printed with -h which I modified to match the README file.
